### PR TITLE
[FEAT] jwt & redis 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ out/
 src/main/resources/application-db.yml
 src/main/resources/application-s3.yml
 src/main/resources/application-aladin.yml
+src/main/resources/application-jwt.yml
 
 ### VS Code ###
 .vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
     implementation 'com.google.code.gson:gson:2.9.0'
 
-    //mysql
+    // mysql
     implementation 'com.mysql:mysql-connector-j'
 
     // flyway
@@ -56,8 +56,16 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-    //AWS S3
+    // AWS S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // JWT
+    implementation 'com.auth0:java-jwt:4.5.0'
+    implementation 'com.auth0:jwks-rsa:0.20.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 def querydslDir = "src/main/generated"

--- a/src/main/java/bonda/bonda/global/config/SecurityConfig.java
+++ b/src/main/java/bonda/bonda/global/config/SecurityConfig.java
@@ -1,15 +1,51 @@
 package bonda.bonda.global.config;
 
+import bonda.bonda.domain.member.domain.repository.MemberRepository;
+import bonda.bonda.global.security.AuthenticationEntryPointImpl;
+import bonda.bonda.global.security.filter.JwtAuthenticationProcessingFilter;
+import bonda.bonda.global.security.jwt.JwtTokenProvider;
+import bonda.bonda.infrastructure.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig {
 
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final RedisUtil redisUtil;
+
     // api 연동 WHITE_LIST
     private final String[] WHITE_LIST= { "/auth/**","/books/**" };
 
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception.authenticationEntryPoint(new AuthenticationEntryPointImpl()))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(WHITE_LIST).permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter() {
+        return new JwtAuthenticationProcessingFilter(jwtTokenProvider, memberRepository, redisUtil);
+    }
 }

--- a/src/main/java/bonda/bonda/global/security/AuthenticationEntryPointImpl.java
+++ b/src/main/java/bonda/bonda/global/security/AuthenticationEntryPointImpl.java
@@ -1,0 +1,17 @@
+package bonda.bonda.global.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getLocalizedMessage());
+    }
+}

--- a/src/main/java/bonda/bonda/global/security/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/bonda/bonda/global/security/filter/JwtAuthenticationProcessingFilter.java
@@ -1,0 +1,49 @@
+package bonda.bonda.global.security.filter;
+
+import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.domain.member.domain.repository.MemberRepository;
+import bonda.bonda.global.security.jwt.JwtTokenProvider;
+import bonda.bonda.infrastructure.redis.RedisUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final RedisUtil redisUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        checkAccessTokenAndAuthentication(request, response, filterChain);
+    }
+
+    private void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        jwtTokenProvider.extractAccessToken(request)
+                .filter(jwtTokenProvider::isTokenValid)
+                .filter(accessToken -> !jwtTokenProvider.isTokenInBlackList(accessToken))
+                .flatMap(jwtTokenProvider::extractMemberId)
+                .flatMap(memberRepository::findById)
+                .ifPresent(this::saveAuthentication);
+        filterChain.doFilter(request, response);
+    }
+
+    private void saveAuthentication(Member member) {
+        Authentication authentication = new UsernamePasswordAuthenticationToken(member, null, Collections.emptyList());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+}

--- a/src/main/java/bonda/bonda/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/bonda/bonda/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,32 @@
+package bonda.bonda.global.security.jwt;
+
+import bonda.bonda.domain.member.domain.Member;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Optional;
+
+public interface JwtTokenProvider {
+
+    String createAccessToken(Member member);
+
+    String createRefreshToken();
+
+    void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken);
+
+    void sendAccessToken(HttpServletResponse response, String accessToken);
+
+    Optional<String> extractAccessToken(HttpServletRequest request);
+
+    Optional<String> extractRefreshToken(HttpServletRequest request);
+
+    Optional<Long> extractMemberId(String accessToken);
+
+    void setAccessTokenHeader(HttpServletResponse response, String accessToken);
+
+    void setRefreshTokenHeader(HttpServletResponse response, String refreshToken);
+
+    boolean isTokenValid(String token);
+
+    boolean isTokenInBlackList(String accessToken);
+}

--- a/src/main/java/bonda/bonda/global/security/jwt/JwtTokenProviderImpl.java
+++ b/src/main/java/bonda/bonda/global/security/jwt/JwtTokenProviderImpl.java
@@ -1,0 +1,154 @@
+package bonda.bonda.global.security.jwt;
+
+import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.infrastructure.redis.RedisUtil;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+@Setter(value = AccessLevel.PRIVATE)
+@Slf4j
+public class JwtTokenProviderImpl implements JwtTokenProvider {
+
+    private final RedisUtil redisUtil;
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access.expiration}")
+    private Long accessExpiration;
+
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshExpiration;
+
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+
+    @Value("${jwt.refresh.header}")
+    private String refreshHeader;
+
+    private static final String BL_AT_PREFIX = "BL_AT_";
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String USERNAME_CLAIM = "nickname";
+    private static final String USERID_CLAIM = "id";
+    private static final String BEARER = "Bearer ";
+
+    // 메서드
+    @Override
+    public String createAccessToken(Member member) {
+        return JWT.create()
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(System.currentTimeMillis() + accessExpiration * 1000))
+                .withClaim(USERID_CLAIM, member.getId())
+                .withClaim(USERNAME_CLAIM, member.getNickname())
+                .sign(Algorithm.HMAC512(secret));
+    }
+
+    @Override
+    public String createRefreshToken() {
+        return JWT.create()
+                .withSubject(REFRESH_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(System.currentTimeMillis() + refreshExpiration * 1000))
+                .sign(Algorithm.HMAC512(secret));
+    }
+
+    @Override
+    public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        setAccessTokenHeader(response, accessToken);
+        setRefreshTokenHeader(response, refreshToken);
+
+        Map<String, String> tokenMap = new HashMap<>();
+        tokenMap.put(ACCESS_TOKEN_SUBJECT, accessToken);
+        tokenMap.put(REFRESH_TOKEN_SUBJECT, refreshToken);
+    }
+
+    @Override
+    public void sendAccessToken(HttpServletResponse response, String accessToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        setAccessTokenHeader(response, accessToken);
+
+        Map<String, String> tokenMap = new HashMap<>();
+        tokenMap.put(ACCESS_TOKEN_SUBJECT, accessToken);
+    }
+
+    @Override
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(accessHeader)).filter(
+                accessToken -> accessToken.startsWith(BEARER)
+        ).map(accessToken -> accessToken.replace(BEARER, ""));
+    }
+
+    @Override
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(refreshHeader)).filter(
+                refreshToken -> refreshToken.startsWith(BEARER)
+        ).map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    @Override
+    public Optional<Long> extractMemberId(String accessToken) {
+        try {
+            return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secret))
+                    .build()
+                    .verify(accessToken)
+                    .getClaim(USERID_CLAIM)
+                    .asLong());
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+        response.setHeader(accessHeader, accessToken);
+    }
+
+    @Override
+    public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
+        response.setHeader(refreshHeader, refreshToken);
+    }
+
+    @Override
+    public boolean isTokenValid(String token) {
+        try {
+            JWT.require(Algorithm.HMAC512(secret)).build().verify(token);
+            return true;
+        } catch (TokenExpiredException ex) {
+            log.error("만료된 JWT 토큰입니다.");
+            return false;
+        } catch (Exception e) {
+            log.error("유효하지 않은 Token입니다", e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isTokenInBlackList(String accessToken) {
+        // Redis에서 블랙리스트로 저장된 토큰 확인
+        String blacklistToken = redisUtil.getData(BL_AT_PREFIX + accessToken);
+        return blacklistToken != null;
+    }
+}

--- a/src/main/java/bonda/bonda/infrastructure/redis/RedisConfig.java
+++ b/src/main/java/bonda/bonda/infrastructure/redis/RedisConfig.java
@@ -1,0 +1,36 @@
+package bonda.bonda.infrastructure.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+//        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword(password);
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisEmailAuthenticationTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory((redisConnectionFactory()));
+        return redisTemplate;
+    }
+}

--- a/src/main/java/bonda/bonda/infrastructure/redis/RedisUtil.java
+++ b/src/main/java/bonda/bonda/infrastructure/redis/RedisUtil.java
@@ -1,0 +1,39 @@
+package bonda.bonda.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Component
+public class RedisUtil {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    public boolean existData(String key) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
+    }
+
+    public void setData(String key, String value) {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        valueOperations.set(key, value);
+    }
+
+    public void setDataExpire(String key, String value, long duration) {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public void deleteData(String key) {
+        stringRedisTemplate.delete(key);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: ["db","s3", "aladin"]
+    active: ["db","s3", "aladin", "jwt"]


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [ ] jwt 설정
- [ ] redis 설정

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #13 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

jwt 및 redis 관련 설정입니다.

JwtTokenProvider에는 jwt관련 메서드를 정의해놓은 것입니다.
JwtAuthenticationProcessingFilter는 security에 들어가는 FilterChain에 대한 내용입니다.
- filter(jwtTokenProvider::isTokenValid)는 jwtTokenProvider에 있는 토큰 유효성 검사를 통해 유효한 토큰만 통과할 수 있도록 하는 필터입니다.
- filter(accessToken~)는 Redis에 "BL_AT_"가 접두사로 들어가있는 토큰이 있는지 확인합니다. 회원 로그아웃을 한 경우 redis에 저장된 AccessToken을 재사용하지 않도록 BlackList에 넣기 떄문에 그 블랙리스트에 있는 AccessToken을 확인합니다.
- flatMap(~::extractMemberId)는 token에 hash되어 저장된 memberId값을 추출합니다.
- flatMap(memberRepository:findById)는 추출한 memberId값으로 db에 저장된 member를 찾습니다.

SecurityConfig에 Http 접근에 대한 FilterChain을 추가했습니다. 이제 http에 접속이 가능합니다. 다음 기능부터 swagger 추가하도록 하겠습니다. 어떤 방식을 사용하실진 모르겠지만 제가 AuthController에 swagger 정보를 위한 repository를 생성하고 DTO 관련해선 Schema 어노테이션을 사용할 예정입니다. swagger 관련해선 다음 기능 개발 때 따로 comment로 달아놓겠습니다.