### PR TITLE
[FEAT]: 카카오 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 }
 
 def querydslDir = "src/main/generated"

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     implementation 'com.google.code.gson:gson:2.9.0'

--- a/src/main/java/bonda/bonda/domain/auth/application/AuthService.java
+++ b/src/main/java/bonda/bonda/domain/auth/application/AuthService.java
@@ -1,6 +1,15 @@
 package bonda.bonda.domain.auth.application;
 
+import bonda.bonda.domain.auth.dto.request.LoginReq;
+import bonda.bonda.domain.member.dto.response.KakaoMemberRes;
+import bonda.bonda.domain.auth.dto.response.LoginRes;
+import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.domain.member.domain.repository.MemberRepository;
+import bonda.bonda.global.common.SuccessResponse;
+import bonda.bonda.global.security.jwt.JwtTokenProvider;
+import bonda.bonda.infrastructure.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,4 +18,51 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshExpiration;     // RefreshToken 유효기간(2주)
+
+    private static String RT_PREFIX = "RT_";        // RefreshToken 접두사
+    private static String BL_AT_PREFIX = "BL_AT_";  // Blacklist에 등록된 AccessToken 접두사
+
+    private final KakaoTokenValidator kakaoTokenValidator;
+    private final MemberRepository memberRepository;
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisUtil redisUtil;
+
+    @Transactional
+    public SuccessResponse<LoginRes> signUpOrLogin(LoginReq loginReq) {
+        String idToken = loginReq.getIdToken();
+        KakaoMemberRes kakaoMemberRes = kakaoTokenValidator.validateAndExtract(idToken);
+
+        Member member = memberRepository.findByKakaoId(kakaoMemberRes.getKakaoId())
+                .orElseGet(() -> registerNewMember(kakaoMemberRes));
+
+        boolean isNewMember = member.getNickname().startsWith("|KAKAO");      // |KAKAO로 시작하는 닉네임을 신규 유저로 생각
+
+        String accessToken = jwtTokenProvider.createAccessToken(member);      // AccessToken 생성
+        String refreshToken = jwtTokenProvider.createRefreshToken();          // RefreshToken 생성
+
+        redisUtil.setDataExpire(RT_PREFIX + refreshToken, member.getNickname(), refreshExpiration);
+
+        LoginRes loginRes = LoginRes.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .isNewUser(isNewMember)
+                .build();
+
+        return SuccessResponse.of(loginRes);
+    }
+
+    private Member registerNewMember(KakaoMemberRes kakaoMemberRes) {
+        Member member = Member.builder()
+                .kakaoId(kakaoMemberRes.getKakaoId())
+                .nickname("|KAKAO" + (int)(Math.random() * 9000 + 1000))    // |KAKAO+랜덤숫자로 임의의 nickname 설정
+                .profileImage(null)     // profileImage를 null로 저장하는 것은 기획에 따라 리팩토링 예정
+                .build();
+
+        memberRepository.save(member);
+
+        return member;
+    }
 }

--- a/src/main/java/bonda/bonda/domain/auth/application/KakaoTokenValidator.java
+++ b/src/main/java/bonda/bonda/domain/auth/application/KakaoTokenValidator.java
@@ -1,0 +1,39 @@
+package bonda.bonda.domain.auth.application;
+
+import bonda.bonda.domain.auth.dto.response.KakaoMemberRes;
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.UrlJwkProvider;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.net.URL;
+import java.security.interfaces.RSAPublicKey;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoTokenValidator {
+
+    public KakaoMemberRes validateAndExtract(String idToken) {
+        try {
+            JwkProvider jwkProvider = new UrlJwkProvider(new URL("https://kauth.kakao.com/.well-known/jwks.json"));
+            DecodedJWT decodedJWT = JWT.decode(idToken);
+
+            Jwk jwk = jwkProvider.get(decodedJWT.getKeyId());
+            Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
+
+            JWTVerifier verifier = JWT.require(algorithm).build();
+            verifier.verify(idToken);
+
+            String sub = decodedJWT.getClaim("sub").asString();
+
+            return new KakaoMemberRes(sub);
+        } catch (Exception e) {
+            throw new RuntimeException("유효하지 않은 kakao_idToken 입니다." + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/bonda/bonda/domain/auth/application/KakaoTokenValidator.java
+++ b/src/main/java/bonda/bonda/domain/auth/application/KakaoTokenValidator.java
@@ -1,14 +1,15 @@
 package bonda.bonda.domain.auth.application;
 
-import bonda.bonda.domain.auth.dto.response.KakaoMemberRes;
+import bonda.bonda.domain.member.dto.response.KakaoMemberRes;
 import com.auth0.jwk.Jwk;
 import com.auth0.jwk.JwkProvider;
 import com.auth0.jwk.UrlJwkProvider;
 import com.auth0.jwt.JWT;
-import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.JWTVerifier;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.net.URL;
@@ -16,6 +17,7 @@ import java.security.interfaces.RSAPublicKey;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class KakaoTokenValidator {
 
     public KakaoMemberRes validateAndExtract(String idToken) {

--- a/src/main/java/bonda/bonda/domain/auth/dto/request/LoginReq.java
+++ b/src/main/java/bonda/bonda/domain/auth/dto/request/LoginReq.java
@@ -1,0 +1,11 @@
+package bonda.bonda.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class LoginReq {
+
+    @NotNull
+    private String idToken;
+}

--- a/src/main/java/bonda/bonda/domain/auth/dto/request/LoginReq.java
+++ b/src/main/java/bonda/bonda/domain/auth/dto/request/LoginReq.java
@@ -1,11 +1,13 @@
 package bonda.bonda.domain.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class LoginReq {
 
+    @Schema(type = "String", example = "kakao.id.Token", description = "프론트로부터 받은 kakao의 idToken 입니다.")
     @NotNull
     private String idToken;
 }

--- a/src/main/java/bonda/bonda/domain/auth/dto/response/KakaoMemberRes.java
+++ b/src/main/java/bonda/bonda/domain/auth/dto/response/KakaoMemberRes.java
@@ -1,0 +1,11 @@
+package bonda.bonda.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class KakaoMemberRes {
+
+    private String kakaoId;
+}

--- a/src/main/java/bonda/bonda/domain/auth/dto/response/LoginRes.java
+++ b/src/main/java/bonda/bonda/domain/auth/dto/response/LoginRes.java
@@ -1,5 +1,6 @@
 package bonda.bonda.domain.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,9 +8,12 @@ import lombok.Data;
 @Builder
 public class LoginRes {
 
+    @Schema(type = "String", example = "jwtAccessToken", description = "AccessToken을 출력합니다.")
     private String accessToken;
 
+    @Schema(type = "String", example = "jwtRefreshToken", description = "RefreshToken을 출력합니다.")
     private String refreshToken;
 
+    @Schema(type = "Boolean", example = "true", description = "신규 멤버인지 확인합니다. true면 회원가입 관련으로 false면 로그인 관련으로 이어집니다.")
     private Boolean isNewUser;
 }

--- a/src/main/java/bonda/bonda/domain/auth/dto/response/LoginRes.java
+++ b/src/main/java/bonda/bonda/domain/auth/dto/response/LoginRes.java
@@ -1,0 +1,15 @@
+package bonda.bonda.domain.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LoginRes {
+
+    private String accessToken;
+
+    private String refreshToken;
+
+    private Boolean isNewUser;
+}

--- a/src/main/java/bonda/bonda/domain/auth/presentation/AuthApi.java
+++ b/src/main/java/bonda/bonda/domain/auth/presentation/AuthApi.java
@@ -1,0 +1,37 @@
+package bonda.bonda.domain.auth.presentation;
+
+import bonda.bonda.domain.auth.dto.request.LoginReq;
+import bonda.bonda.domain.auth.dto.response.LoginRes;
+import bonda.bonda.global.common.SuccessResponse;
+import bonda.bonda.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Auth API", description = "인증 관련 API입니다.")
+public interface AuthApi {
+
+    @Operation(summary = "회원가입 또는 로그인", description = "회원가입 또는 로그인을 합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "회원가입 혹은 로그인 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = LoginRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "회원가입 혹은 로그인 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            )
+    })
+    @PostMapping("/login")
+    ResponseEntity<SuccessResponse<LoginRes>> signUpOrLogin(
+            @Parameter(description = "Schemas의 LoginReq 참고", required = true) @Valid @RequestBody LoginReq loginReq
+    );
+}

--- a/src/main/java/bonda/bonda/domain/auth/presentation/AuthController.java
+++ b/src/main/java/bonda/bonda/domain/auth/presentation/AuthController.java
@@ -4,6 +4,7 @@ import bonda.bonda.domain.auth.application.AuthService;
 import bonda.bonda.domain.auth.dto.request.LoginReq;
 import bonda.bonda.domain.auth.dto.response.LoginRes;
 import bonda.bonda.global.common.SuccessResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,12 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/auth")
-public class AuthController {
+public class AuthController implements AuthApi {
 
     private final AuthService authService;
 
+    @Override
     @PostMapping("/login")
-    public ResponseEntity<SuccessResponse<LoginRes>> signUpOrLogin(@RequestBody LoginReq loginReq) {
+    public ResponseEntity<SuccessResponse<LoginRes>> signUpOrLogin(@Valid @RequestBody LoginReq loginReq) {
         return ResponseEntity.ok(authService.signUpOrLogin(loginReq));
     }
 }

--- a/src/main/java/bonda/bonda/domain/auth/presentation/AuthController.java
+++ b/src/main/java/bonda/bonda/domain/auth/presentation/AuthController.java
@@ -1,6 +1,13 @@
 package bonda.bonda.domain.auth.presentation;
 
+import bonda.bonda.domain.auth.application.AuthService;
+import bonda.bonda.domain.auth.dto.request.LoginReq;
+import bonda.bonda.domain.auth.dto.response.LoginRes;
+import bonda.bonda.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +16,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 public class AuthController {
 
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<SuccessResponse<LoginRes>> signUpOrLogin(@RequestBody LoginReq loginReq) {
+        return ResponseEntity.ok(authService.signUpOrLogin(loginReq));
+    }
 }

--- a/src/main/java/bonda/bonda/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/bonda/bonda/domain/member/domain/repository/MemberRepository.java
@@ -3,6 +3,9 @@ package bonda.bonda.domain.member.domain.repository;
 import bonda.bonda.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByKakaoId(String kakaoId);
 }

--- a/src/main/java/bonda/bonda/domain/member/dto/response/KakaoMemberRes.java
+++ b/src/main/java/bonda/bonda/domain/member/dto/response/KakaoMemberRes.java
@@ -1,5 +1,6 @@
 package bonda.bonda.domain.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -7,5 +8,6 @@ import lombok.Data;
 @AllArgsConstructor
 public class KakaoMemberRes {
 
+    @Schema(type = "String", example = "1234567890", description = "카카오 사용자의 아이디 번호입니다.")
     private String kakaoId;
 }

--- a/src/main/java/bonda/bonda/domain/member/dto/response/KakaoMemberRes.java
+++ b/src/main/java/bonda/bonda/domain/member/dto/response/KakaoMemberRes.java
@@ -1,4 +1,4 @@
-package bonda.bonda.domain.auth.dto.response;
+package bonda.bonda.domain.member.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/bonda/bonda/global/annotation/LoginMember.java
+++ b/src/main/java/bonda/bonda/global/annotation/LoginMember.java
@@ -1,0 +1,11 @@
+package bonda.bonda.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember {
+}

--- a/src/main/java/bonda/bonda/global/config/SecurityConfig.java
+++ b/src/main/java/bonda/bonda/global/config/SecurityConfig.java
@@ -25,7 +25,10 @@ public class SecurityConfig {
     private final RedisUtil redisUtil;
 
     // api 연동 WHITE_LIST
-    private final String[] WHITE_LIST= { "/auth/**","/books/**" };
+    private final String[] WHITE_LIST= {
+            "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",    // swagger
+            "/auth/**", "/books/**"
+    };
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/bonda/bonda/global/config/SecurityConfig.java
+++ b/src/main/java/bonda/bonda/global/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
@@ -42,7 +43,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(WHITE_LIST).permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationProcessingFilter(), LogoutFilter.class)
+        ;
 
         return http.build();
     }

--- a/src/main/java/bonda/bonda/global/config/SwaggerConfig.java
+++ b/src/main/java/bonda/bonda/global/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package bonda.bonda.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Bonda API")
+                .description("Bonda API 목록입니다.")
+                .version("v1.0.0");
+
+        return new OpenAPI().info(info);
+    }
+}

--- a/src/main/java/bonda/bonda/global/config/WebMvcConfig.java
+++ b/src/main/java/bonda/bonda/global/config/WebMvcConfig.java
@@ -1,0 +1,23 @@
+package bonda.bonda.global.config;
+
+import bonda.bonda.global.resolver.LoginMemberArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    public WebMvcConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/bonda/bonda/global/resolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/bonda/bonda/global/resolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,32 @@
+package bonda.bonda.global.resolver;
+
+import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.global.annotation.LoginMember;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginMember.class) && parameter.getParameterType().equals(Member.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new IllegalStateException("로그인 정보가 없습니다.");
+        }
+
+        return (Member) authentication.getPrincipal();
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 카카오 로그인 및 회원가입
- [x] swagger 설정
- [x] @LoginMember 어노테이션 추가

### 📷 스크린샷
![스크린샷 2025-05-28 171459](https://github.com/user-attachments/assets/5f891f86-0827-48b3-a16f-bde4d99b465f)

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #15 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

kakao와 jwt 연동시킨 카카오 로그인 및 회원가입입니다.
1. 처음 로그인할 때 idToken에 있는 kakaoId가 db에 없다면 registerNewMember 메서드를 실행합니다.
2. Response값에 있는 boolean값은 닉네임에 "|KAKAO"로 시작되는 경우 true로 출력합니다. 따라서, 닉네임을 db에서 임의로 수정하거나, 닉네임 수정 기능을 구현하기 전까진 isNewMember가 true로 출력될 것 같습니다.
3. swagger 설정도 완료했습니다. 이전에 swagger를 어떻게 하셨는지 모르겠지만, 이번 프로젝트에선 다음과 같이 구현하겠습니다. 천천히 읽어보세요
4. token 검증을 위해서 @LoginMember 어노테이션을 커스텀해서 추가했습니다. 이제 Member를 확인해야 할 경우 @LoginMember를 추가해주세요.