### PR TITLE
[FEAT] 도서 검색 기능 개발 완료

### DIFF
--- a/src/main/java/bonda/bonda/domain/book/application/BookSearchService.java
+++ b/src/main/java/bonda/bonda/domain/book/application/BookSearchService.java
@@ -1,4 +1,9 @@
 package bonda.bonda.domain.book.application;
 
+import bonda.bonda.domain.book.dto.response.*;
+import bonda.bonda.global.common.SuccessResponse;
+
 public interface BookSearchService {
+    SuccessResponse<SearchBookListRes> searchBookList(Integer page, Integer size, String orderBy, String word);
+
 }

--- a/src/main/java/bonda/bonda/domain/book/application/BookSearchServiceImpl.java
+++ b/src/main/java/bonda/bonda/domain/book/application/BookSearchServiceImpl.java
@@ -1,10 +1,8 @@
 package bonda.bonda.domain.book.application;
 
 import bonda.bonda.domain.book.domain.Book;
-import bonda.bonda.domain.book.domain.BookCategory;
 import bonda.bonda.domain.book.domain.repository.BookRepository;
-import bonda.bonda.domain.book.dto.response.BookListByCategoryRes;
-import bonda.bonda.domain.book.dto.response.BookListRes;
+import bonda.bonda.domain.book.dto.response.*;
 import bonda.bonda.global.common.SuccessResponse;
 import bonda.bonda.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -15,39 +13,29 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static bonda.bonda.domain.book.dto.BookMapper.convertToBookListRes;
-import static bonda.bonda.global.exception.ErrorCode.INVALID_BOOK_CATEGORY;
 import static bonda.bonda.global.exception.ErrorCode.NOT_FOUND_ERROR;
 
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Service
-public class BookReadServiceImpl implements BookReadService {
+@Transactional
+@RequiredArgsConstructor
+public class BookSearchServiceImpl implements BookSearchService {
     private final BookRepository bookRepository;
 
     @Override
-    public SuccessResponse<BookListByCategoryRes> bookListByCategory(Integer page, Integer size, String orderBy, String category) {
-        if(BookCategory.isValid(category) == false) {
-            throw new BusinessException("Invalid book category: " + category, INVALID_BOOK_CATEGORY);
-        }
-
+    public SuccessResponse<SearchBookListRes> searchBookList(Integer page, Integer size, String orderBy, String word) {
         Pageable pageable = PageRequest.of(page, size);
-
-        Page<Book> bookList = bookRepository.findBookListByCategory(pageable, orderBy, category).orElseThrow(() -> new BusinessException(NOT_FOUND_ERROR));
-        //Book 리스트를 bookListRes로 변환
+        Page<Book> bookList = bookRepository.searchBookList(pageable, orderBy, word).orElseThrow(() -> new BusinessException(NOT_FOUND_ERROR));
         List<BookListRes> bookListRes = convertToBookListRes(bookList.getContent());
 
-        return SuccessResponse.of(BookListByCategoryRes.builder()
+        return SuccessResponse.of(SearchBookListRes.builder()
                 .page(page)
                 .total(bookList.getTotalElements())
-                .category(category)
+                .word(word)
                 .orderBy(orderBy)
                 .hasNextPage(bookList.hasNext())
                 .bookList(bookListRes)
                 .build());
     }
-
-
 }

--- a/src/main/java/bonda/bonda/domain/book/domain/Subject.java
+++ b/src/main/java/bonda/bonda/domain/book/domain/Subject.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @Getter
 public enum Subject {
 
+
+    ALL("ALL", "전체"),
     COOKING("COOKING","요리"),
     SELF_DEVELOPMENT("SELF_DEVELOPMENT","자기계발"),
     TRAVEL("TRAVEL","로컬/여행"),

--- a/src/main/java/bonda/bonda/domain/book/domain/repository/BookRepository.java
+++ b/src/main/java/bonda/bonda/domain/book/domain/repository/BookRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<Book, Long> , BookRepositoryCustom {
 
-    Integer countByBookCategory(String category);
 }

--- a/src/main/java/bonda/bonda/domain/book/domain/repository/BookRepositoryCustom.java
+++ b/src/main/java/bonda/bonda/domain/book/domain/repository/BookRepositoryCustom.java
@@ -12,4 +12,6 @@ public interface BookRepositoryCustom {
     Book queryDslInitTest(String name); // QueryDsl 테스트 용 메소드
 
     Optional<Page<Book>> findBookListByCategory(Pageable pageable, String orderBy, String category);
+    Optional<Page<Book>> searchBookList(Pageable pageable, String orderBy, String word);
+
 }

--- a/src/main/java/bonda/bonda/domain/book/dto/BookMapper.java
+++ b/src/main/java/bonda/bonda/domain/book/dto/BookMapper.java
@@ -1,0 +1,21 @@
+package bonda.bonda.domain.book.dto;
+
+import bonda.bonda.domain.book.domain.Book;
+import bonda.bonda.domain.book.dto.response.BookListRes;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BookMapper {
+    public static List<BookListRes> convertToBookListRes(List<Book> bookList) {
+        return bookList.stream()
+                .map(book -> BookListRes.builder()
+                        .id(book.getId())
+                        .title(book.getTitle())
+                        .author(book.getWriter())
+                        .imageUrl(book.getImage())
+                        .subject(book.getSubject() != null ? book.getSubject().getValue() : null)
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/bonda/bonda/domain/book/dto/request/BookSaveReq.java
+++ b/src/main/java/bonda/bonda/domain/book/dto/request/BookSaveReq.java
@@ -1,8 +1,14 @@
 package bonda.bonda.domain.book.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 @Data
 public class BookSaveReq {
+    @Schema(type = "String", example = "NOVEL", description = "DB에 적제될 본다 카테고리 입니다.")
+    @NotNull
     String category;
+    @Schema(type = "Long", example = "50930", description = "알라딘 api에 요청할 카테고리 ID 입니다.")
+    @NotNull
     Long categoryId;
 }

--- a/src/main/java/bonda/bonda/domain/book/dto/response/SearchBookListRes.java
+++ b/src/main/java/bonda/bonda/domain/book/dto/response/SearchBookListRes.java
@@ -1,0 +1,18 @@
+package bonda.bonda.domain.book.dto.response;
+
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class SearchBookListRes {
+    Integer page;
+    Long total;
+    String word;
+    String orderBy;
+    Boolean hasNextPage;
+    List<BookListRes> bookList;
+}

--- a/src/main/java/bonda/bonda/domain/book/presentation/BookApi.java
+++ b/src/main/java/bonda/bonda/domain/book/presentation/BookApi.java
@@ -1,0 +1,93 @@
+package bonda.bonda.domain.book.presentation;
+
+import bonda.bonda.domain.book.dto.request.BookSaveReq;
+import bonda.bonda.domain.book.dto.response.BookListByCategoryRes;
+import bonda.bonda.domain.book.dto.response.SearchBookListRes;
+import bonda.bonda.global.common.Message;
+import bonda.bonda.global.common.SuccessResponse;
+import bonda.bonda.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Book API", description = "도서 관련 API입니다.")
+public interface BookApi {
+
+    @Operation(summary = "도서 홈 화면", description = "카테고리별로 도서를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "카테고리별 도서 조회 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = BookListByCategoryRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "카테고리별 도서 조회 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            )
+    })
+    @GetMapping()
+    public ResponseEntity<SuccessResponse<BookListByCategoryRes>> getBookListByCategory(
+
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지당 항목 수", example = "24")
+            @RequestParam(defaultValue = "24") int size,
+            @Parameter(description = "정렬 기준 (예: popularity, recent)", example = "popularity")
+            @RequestParam(defaultValue = "popularity") String orderBy,
+            @Parameter(description = "카테고리명 (예: ALL, POEM, NOVEL 등)", example = "ALL")
+            @RequestParam(defaultValue = "ALL") String category);
+
+
+
+    @Operation(
+            summary = "도서 DB",
+            description = "알라딘 API를 호출하여, 새로운 도서를 등록합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201", description = "도서 등록 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "잘못된 요청",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            )
+    })
+    @PostMapping("/new")
+    public ResponseEntity<SuccessResponse<Message>> createPost(@Valid @RequestBody BookSaveReq postReq);
+
+
+    @Operation(summary = "도서 검색", description = "키워드로 도서를 검색합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "도서 검색 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = SearchBookListRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "도서 검색 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            )
+    })
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<SearchBookListRes>> searchBookList(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "페이지당 항목 수", example = "24")
+            @RequestParam(defaultValue = "24") int size,
+
+            @Parameter(description = "정렬 기준 (예: newest, relevance)", example = "newest")
+            @RequestParam(defaultValue = "newest") String orderBy,
+
+            @Parameter(description = "검색 키워드", example = "자바")
+            @RequestParam String word);
+}

--- a/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
+++ b/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
@@ -2,8 +2,10 @@ package bonda.bonda.domain.book.presentation;
 
 import bonda.bonda.domain.book.application.BookCommandService;
 import bonda.bonda.domain.book.application.BookReadService;
+import bonda.bonda.domain.book.application.BookSearchService;
 import bonda.bonda.domain.book.dto.request.BookSaveReq;
 import bonda.bonda.domain.book.dto.response.BookListByCategoryRes;
+import bonda.bonda.domain.book.dto.response.SearchBookListRes;
 import bonda.bonda.global.common.Message;
 import bonda.bonda.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class BookController {
     private final BookReadService bookReadService;
     private final BookCommandService bookCommandService;
+    private final BookSearchService bookSearchService;
     @GetMapping()
     public ResponseEntity<SuccessResponse<BookListByCategoryRes>> getBookListByCategory(
             @RequestParam(defaultValue = "0") int page,
@@ -30,5 +33,13 @@ public class BookController {
         return ResponseEntity.ok(bookCommandService.saveBook(postReq));
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<SearchBookListRes>> searchBookList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "24") int size,
+            @RequestParam(defaultValue = "newest") String orderBy,
+            @RequestParam String word) {
+        return ResponseEntity.ok(bookSearchService.searchBookList(page, size, orderBy, word));
+    }
 
 }

--- a/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
+++ b/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
@@ -8,6 +8,7 @@ import bonda.bonda.domain.book.dto.response.BookListByCategoryRes;
 import bonda.bonda.domain.book.dto.response.SearchBookListRes;
 import bonda.bonda.global.common.Message;
 import bonda.bonda.global.common.SuccessResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,10 +16,11 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/books")
-public class BookController {
+public class BookController implements BookApi {
     private final BookReadService bookReadService;
     private final BookCommandService bookCommandService;
     private final BookSearchService bookSearchService;
+
     @GetMapping()
     public ResponseEntity<SuccessResponse<BookListByCategoryRes>> getBookListByCategory(
             @RequestParam(defaultValue = "0") int page,
@@ -29,7 +31,7 @@ public class BookController {
     }
 
     @PostMapping("/new")
-    public ResponseEntity<SuccessResponse<Message>> createPost(@RequestBody BookSaveReq postReq) {
+    public ResponseEntity<SuccessResponse<Message>> createPost(@Valid @RequestBody BookSaveReq postReq) {
         return ResponseEntity.ok(bookCommandService.saveBook(postReq));
     }
 

--- a/src/main/java/bonda/bonda/global/security/AuthenticationEntryPointImpl.java
+++ b/src/main/java/bonda/bonda/global/security/AuthenticationEntryPointImpl.java
@@ -3,11 +3,12 @@ package bonda.bonda.global.security;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
 import java.io.IOException;
-
+@Slf4j
 public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
 
     @Override


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

![Image](https://github.com/user-attachments/assets/6a7d045d-fd71-4a07-9fe6-1f6e2c36ffaa)

![Image](https://github.com/user-attachments/assets/c641a794-bc0c-463b-9abd-7796c0c79a7a)

전체 검색 페이지의 도서 검색과, 도서 검색 페이지의 결과를 모두 담당하는 api 입니다.

- [x] 기능 구현
- [x] 테스트


해당 단어가 포함된 제목의 도서 조회 

![Image](https://github.com/user-attachments/assets/9a8b2131-ba5e-477e-bcca-939b64dcbac4)

단어의 앞뒤에 공백이 있는 경우 -> trim으로 공백 제거

![Image](https://github.com/user-attachments/assets/242823dd-3a33-458b-8e4f-ac433cecdb7d)

단어가 공백으로 되어 있는 경우 -> 단어의 결과의 교집합

- 두 개 다 포함되는 경우

![Image](https://github.com/user-attachments/assets/d7a21d02-27c6-4cb4-9cc9-5fd77c64cbc8)

- 하나만 포함되는 경우 -> 교집합이므로 결과 x 

![Image](https://github.com/user-attachments/assets/3b86544f-12b9-4873-bdb5-fb5d41fa9c4d)


생성된 쿼리 -> 인기순 정렬 + "고래 북마크" 검색

-- 첫번째 쿼리: 실제 데이터 조회 (페이징 적용)
select
    b1_0.id,
    b1_0.book_category,
    b1_0.content,
    b1_0.created_at,
    b1_0.image,
    b1_0.introduction,
    b1_0.page,
    b1_0.publish_date,
    b1_0.publisher,
    b1_0.size,
    b1_0.subject,
    b1_0.title,
    b1_0.writer
from
    book b1_0
where
    lower(b1_0.title) like ? escape '!'  -- 첫번째 단어 and 조건 (예: '고래')
    and lower(b1_0.title) like ? escape '!'  -- 두번째 단어 and 조건 (예: '북마크')
order by
    b1_0.publish_date desc,  -- 출판일 내림차순 정렬
    b1_0.publisher          -- 출판사 오름차순 정렬
limit
    ?, ?  -- 페이징(offset, limit)
;

-- 두번째 쿼리: 총 결과 수 조회 (페이징 위해)
select
    count(b1_0.id)
from
    book b1_0
where
    lower(b1_0.title) like ? escape '!'
    and lower(b1_0.title) like ? escape '!'
;
 



## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
#12 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요
![image](https://github.com/user-attachments/assets/71fd8918-2e51-4faa-938d-4e485d85674e)
1.  이 부분에 대핸 dto 변환이 자주 발생할 거라고 생각해서 mapper 클래스로 빼서,
static하게 편의 메서드로 빼보았습니다.
2. QueryDSL 부분에서도, 정렬, 페이징 부분은 중복된다고 생각해서,
fetchBookPage 메서드 안에서는 정렬 조건을 담당하고,
createPage 부분은 페이지 추가 정보를 담당하도록 분리해보았습니다.

추후 다른 정렬 조건이 생긴다면, fetchBookPage  부분에 메서드 추가하고,
해당 정렬 조건만 담당하는 메서드만 구현하시면 될 거 같습니다.

+ 저는 주석을 많이 남기는 것을 선호하는 편인데, 재훈님께서는 어떻게 느껴지시나요? 만약 주석이 너무 과하다고 생각하면, 좀 줄여보도록 하겠습니다.