### PR TITLE
[FEAT] 도서 저장 기능 구현 완료

### DIFF
--- a/src/main/java/bonda/bonda/domain/book/application/BookCommandService.java
+++ b/src/main/java/bonda/bonda/domain/book/application/BookCommandService.java
@@ -1,10 +1,13 @@
 package bonda.bonda.domain.book.application;
 
-import bonda.bonda.domain.book.dto.request.BookSaveReq;
+import bonda.bonda.domain.book.dto.request.SaveBookFromAladinReq;
+import bonda.bonda.domain.book.dto.response.SaveBookRes;
+import bonda.bonda.domain.member.domain.Member;
 import bonda.bonda.global.common.Message;
 import bonda.bonda.global.common.SuccessResponse;
 
 public interface BookCommandService {
-    SuccessResponse<Message> saveBook(BookSaveReq request);
+    SuccessResponse<Message> saveBookFromAladin(SaveBookFromAladinReq request);
 
+    SuccessResponse<SaveBookRes> saveBook(Member member, Long bookId);
 }

--- a/src/main/java/bonda/bonda/domain/book/dto/request/SaveBookFromAladinReq.java
+++ b/src/main/java/bonda/bonda/domain/book/dto/request/SaveBookFromAladinReq.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 @Data
-public class BookSaveReq {
+public class SaveBookFromAladinReq {
     @Schema(type = "String", example = "NOVEL", description = "DB에 적제될 본다 카테고리 입니다.")
     @NotNull
     String category;

--- a/src/main/java/bonda/bonda/domain/book/dto/response/SaveBookRes.java
+++ b/src/main/java/bonda/bonda/domain/book/dto/response/SaveBookRes.java
@@ -1,0 +1,12 @@
+package bonda.bonda.domain.book.dto.response;
+
+import bonda.bonda.global.common.Message;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SaveBookRes {
+    Long bookId;
+    Message message;
+}

--- a/src/main/java/bonda/bonda/domain/book/presentation/BookApi.java
+++ b/src/main/java/bonda/bonda/domain/book/presentation/BookApi.java
@@ -1,8 +1,11 @@
 package bonda.bonda.domain.book.presentation;
 
-import bonda.bonda.domain.book.dto.request.BookSaveReq;
+import bonda.bonda.domain.book.dto.request.SaveBookFromAladinReq;
 import bonda.bonda.domain.book.dto.response.BookListByCategoryRes;
+import bonda.bonda.domain.book.dto.response.SaveBookRes;
 import bonda.bonda.domain.book.dto.response.SearchBookListRes;
+import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.global.annotation.LoginMember;
 import bonda.bonda.global.common.Message;
 import bonda.bonda.global.common.SuccessResponse;
 import bonda.bonda.global.exception.ErrorCode;
@@ -15,15 +18,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Book API", description = "도서 관련 API입니다.")
 public interface BookApi {
 
-    @Operation(summary = "도서 홈 화면", description = "카테고리별로 도서를 조회합니다.")
+    @Operation(summary = "도서 홈 화면 (카테고리별 조회)", description = "카테고리별로 도서를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200", description = "카테고리별 도서 조회 성공",
@@ -47,9 +47,8 @@ public interface BookApi {
             @RequestParam(defaultValue = "ALL") String category);
 
 
-
     @Operation(
-            summary = "도서 DB",
+            summary = "도서 DB 저장 (알라딘 api)",
             description = "알라딘 API를 호출하여, 새로운 도서를 등록합니다."
     )
     @ApiResponses(value = {
@@ -63,7 +62,7 @@ public interface BookApi {
             )
     })
     @PostMapping("/new")
-    public ResponseEntity<SuccessResponse<Message>> createPost(@Valid @RequestBody BookSaveReq postReq);
+    public ResponseEntity<SuccessResponse<Message>> saveBookFromAladin(@Valid @RequestBody SaveBookFromAladinReq postReq);
 
 
     @Operation(summary = "도서 검색", description = "키워드로 도서를 검색합니다.")
@@ -90,4 +89,34 @@ public interface BookApi {
 
             @Parameter(description = "검색 키워드", example = "자바")
             @RequestParam String word);
+
+
+
+
+
+
+
+    @Operation(summary = "도서 저장", description = "사용자가 특정 도서를 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "도서 저장 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = SaveBookRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "잘못된 요청 (이미 저장된 도서 등)",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            )
+    })
+    @PostMapping("/save/{bookId}")
+    public ResponseEntity<SuccessResponse<SaveBookRes>> saveBook(
+            @Parameter(description = "도서 ID", example = "123")
+            @PathVariable(value = "bookId") Long bookId,
+            @Parameter(hidden = true) // Swagger에 표시하지 않음 (내부에서 주입되는 로그인 사용자 정보)
+            @LoginMember Member member);
+
 }
+

--- a/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
+++ b/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
@@ -3,9 +3,12 @@ package bonda.bonda.domain.book.presentation;
 import bonda.bonda.domain.book.application.BookCommandService;
 import bonda.bonda.domain.book.application.BookReadService;
 import bonda.bonda.domain.book.application.BookSearchService;
-import bonda.bonda.domain.book.dto.request.BookSaveReq;
+import bonda.bonda.domain.book.dto.request.SaveBookFromAladinReq;
 import bonda.bonda.domain.book.dto.response.BookListByCategoryRes;
+import bonda.bonda.domain.book.dto.response.SaveBookRes;
 import bonda.bonda.domain.book.dto.response.SearchBookListRes;
+import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.global.annotation.LoginMember;
 import bonda.bonda.global.common.Message;
 import bonda.bonda.global.common.SuccessResponse;
 import jakarta.validation.Valid;
@@ -31,8 +34,8 @@ public class BookController implements BookApi {
     }
 
     @PostMapping("/new")
-    public ResponseEntity<SuccessResponse<Message>> createPost(@Valid @RequestBody BookSaveReq postReq) {
-        return ResponseEntity.ok(bookCommandService.saveBook(postReq));
+    public ResponseEntity<SuccessResponse<Message>> saveBookFromAladin(@Valid @RequestBody SaveBookFromAladinReq postReq) {
+        return ResponseEntity.ok(bookCommandService.saveBookFromAladin(postReq));
     }
 
     @GetMapping("/search")
@@ -44,4 +47,9 @@ public class BookController implements BookApi {
         return ResponseEntity.ok(bookSearchService.searchBookList(page, size, orderBy, word));
     }
 
+    @PostMapping("/save/{bookId}")
+    public ResponseEntity<SuccessResponse<SaveBookRes>> saveBook(@PathVariable(value = "bookId") Long bookId, @LoginMember Member member) {
+        return ResponseEntity.ok(bookCommandService.saveBook(member, bookId));
+
+    }
 }

--- a/src/main/java/bonda/bonda/domain/bookcase/repository/BookcaseRepository.java
+++ b/src/main/java/bonda/bonda/domain/bookcase/repository/BookcaseRepository.java
@@ -1,8 +1,11 @@
 package bonda.bonda.domain.bookcase.repository;
 
+import bonda.bonda.domain.book.domain.Book;
 import bonda.bonda.domain.bookcase.Bookcase;
+import bonda.bonda.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookcaseRepository extends JpaRepository<Bookcase, Long> {
 
+    boolean existsByMemberAndBook(Member member, Book book);
 }

--- a/src/main/java/bonda/bonda/domain/member/domain/Member.java
+++ b/src/main/java/bonda/bonda/domain/member/domain/Member.java
@@ -43,4 +43,7 @@ public class Member extends BaseEntity {
         this.badgeCount = 0;
         this.autoSave = true;
     }
+    public void plusSaveCount() {
+        this.saveCount++;
+    }
 }

--- a/src/main/java/bonda/bonda/global/exception/ErrorCode.java
+++ b/src/main/java/bonda/bonda/global/exception/ErrorCode.java
@@ -95,7 +95,14 @@ public enum ErrorCode {
 
     FILE_DELETE_FAILED(500, "B994", "S3 버킷에 파일(이미지) 삭제를 실패했습니다."),
 
-    INVALID_BOOK_CATEGORY(400, "BC001", "유효하지 않은 책 카테고리입니다.");
+    INVALID_BOOK_CATEGORY(400, "BC001", "유효하지 않은 책 카테고리입니다."),
+
+    INVALID_BOOK_Id(400, "BC002", "유효하지 않은 책 아이디."),
+
+    ALREADY_SAVED_BOOK(400, "BC003", "이미 저장한 도서입니다."),
+
+    INVALID_MEMBER(400, "MB001", "유효하지 않은 회원입니다.");
+
 
     // End
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요


![Image](https://github.com/user-attachments/assets/e03a6487-d588-4581-80d0-c2c4302eaf9b)

- [x] 테스트용 데이터 생성 (멤버, 도서)

테스트용 카카오 디벨롭 생성


![Image](https://github.com/user-attachments/assets/8da739f8-702f-4b52-8a64-4cdb75befe1a)

redis 서버 띄우기 성공 (password 사용)

![Image](https://github.com/user-attachments/assets/a1da8e78-8738-4861-b388-709e2605047d)

테스트 멤버 생성

![Image](https://github.com/user-attachments/assets/c94dbc88-499b-42ce-bdac-240098221a9c)

테스트 도서 생성

![Image](https://github.com/user-attachments/assets/a38f8806-1630-4fde-862b-98f5f2c3f5d7)


- [x] 기능 구현

- [x] 테스트
  
 저장한 도서 db 생성 확인 (성공)

![Image](https://github.com/user-attachments/assets/bb0afe03-242f-473c-8e4c-54e83638c72e)

![Image](https://github.com/user-attachments/assets/837bfa23-d42b-4ccf-bcd3-c82323ff3d62)

이미 저장한 도서인 경우

![Image](https://github.com/user-attachments/assets/bfe95ada-01bd-4895-877f-1152a11b43e2)

존재하지 않는 도서인 경우

![Image](https://github.com/user-attachments/assets/8f0d91ad-b9d6-4e97-aa54-a20aa7f8b1d5)


- [x] swagger 문서 작업
![image](https://github.com/user-attachments/assets/f6532bf2-4b77-41a9-80f6-4d378e008f60)




## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
#18 


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

1. save 메서드는 이전에 구현했던 알라딘 api 호출해서 저장하는 기능과 이름이 유사할 거 같아서 기존 알라딘 관련 이름들을 알아보기 쉽게 바꾸었습니다.

2. 도서 케이스, 즉 북마크된 도서를 생성하는 기능이어서, bookcase 페키지 밑에서 개발해야 할지 고민을 했었는데, 재훈님이 보내주셨던 저번 프로젝트를 참고하고, gpt에게도 물어본 결과, 주체는 도서라고 생각하여 도서 페키지 안에서 구현해보았습니다.

3.  @LoginMember로 멤버를 불러와서 서비스단에서 사용할 때, 기존 불러온 멤버는 영속성 상태가 아닌 것 같았습니다. 기존에 그냥 에노테이션으로 가져온 멤버의 저장 도서 수를 수정할 때, 수정 쿼리가 나오지 않아서, 서비스 단에서 한번 더 멤버를 불러와서, 영속화를 시킨 상태로 수정하였습니다. 관련해서, LoginMemberArgumentResolver 여기를 수정해야 하는 지 찾아보았는데, 리졸버는 리졸버의 역할에만 충실해야 한다고 생각하여, 서비스 단에서 다시 불러서, 추가적인 오류 작업을 진행하는 것이 더 안전하다고 판단하여 위와 같은 방식으로 개발해보았습니다.