### PR TITLE
[FEAT] : 최근 검색어 목록 조회

### DIFF
--- a/src/main/java/bonda/bonda/domain/book/application/BookSearchService.java
+++ b/src/main/java/bonda/bonda/domain/book/application/BookSearchService.java
@@ -1,9 +1,10 @@
 package bonda.bonda.domain.book.application;
 
 import bonda.bonda.domain.book.dto.response.*;
+import bonda.bonda.domain.member.domain.Member;
 import bonda.bonda.global.common.SuccessResponse;
 
 public interface BookSearchService {
-    SuccessResponse<SearchBookListRes> searchBookList(Integer page, Integer size, String orderBy, String word);
+    SuccessResponse<SearchBookListRes> searchBookList(Integer page, Integer size, String orderBy, String word, Member member);
 
 }

--- a/src/main/java/bonda/bonda/domain/book/application/BookSearchServiceImpl.java
+++ b/src/main/java/bonda/bonda/domain/book/application/BookSearchServiceImpl.java
@@ -3,6 +3,8 @@ package bonda.bonda.domain.book.application;
 import bonda.bonda.domain.book.domain.Book;
 import bonda.bonda.domain.book.domain.repository.BookRepository;
 import bonda.bonda.domain.book.dto.response.*;
+import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.domain.searchterm.application.SearchTermService;
 import bonda.bonda.global.common.SuccessResponse;
 import bonda.bonda.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -22,10 +24,12 @@ import static bonda.bonda.global.exception.ErrorCode.NOT_FOUND_ERROR;
 @RequiredArgsConstructor
 public class BookSearchServiceImpl implements BookSearchService {
     private final BookRepository bookRepository;
+    private final SearchTermService searchTermService;
 
     @Override
-    public SuccessResponse<SearchBookListRes> searchBookList(Integer page, Integer size, String orderBy, String word) {
+    public SuccessResponse<SearchBookListRes> searchBookList(Integer page, Integer size, String orderBy, String word, Member member) {
         Pageable pageable = PageRequest.of(page, size);
+        searchTermService.saveSearchTerm(member, word);
         Page<Book> bookList = bookRepository.searchBookList(pageable, orderBy, word).orElseThrow(() -> new BusinessException(NOT_FOUND_ERROR));
         List<BookListRes> bookListRes = convertToBookListRes(bookList.getContent());
 

--- a/src/main/java/bonda/bonda/domain/book/presentation/BookApi.java
+++ b/src/main/java/bonda/bonda/domain/book/presentation/BookApi.java
@@ -87,7 +87,10 @@ public interface BookApi {
             @RequestParam(defaultValue = "newest") String orderBy,
 
             @Parameter(description = "검색 키워드", example = "자바")
-            @RequestParam String word);
+            @RequestParam String word,
+
+            @Parameter(hidden = true) // Swagger에 표시하지 않음 (내부에서 주입되는 로그인 사용자 정보)
+            @LoginMember Member member);
 
 
 

--- a/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
+++ b/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
@@ -44,8 +44,9 @@ public class BookController implements BookApi {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "24") int size,
             @RequestParam(defaultValue = "newest") String orderBy,
-            @RequestParam String word) {
-        return ResponseEntity.ok(bookSearchService.searchBookList(page, size, orderBy, word));
+            @RequestParam String word,
+            @LoginMember Member member) {
+        return ResponseEntity.ok(bookSearchService.searchBookList(page, size, orderBy, word, member));
     }
 
     @Override

--- a/src/main/java/bonda/bonda/domain/searchterm/application/SearchTermService.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/application/SearchTermService.java
@@ -44,4 +44,18 @@ public class SearchTermService {
 
         return SuccessResponse.of(message);
     }
+
+    @Transactional
+    public SuccessResponse<RecentSearchRes> getRecentSearchTerms(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadCredentialsException("해당 아이디를 가진 멤버가 없습니다."));
+        List<String> searchTermList = redisUtil.getList(RS_PREFIX + memberId);
+
+        RecentSearchRes recentSearchRes = RecentSearchRes.builder()
+                .recentSearchTermList(searchTermList)
+                .autoSave(member.getAutoSave())
+                .build();
+
+        return SuccessResponse.of(recentSearchRes);
+    }
 }

--- a/src/main/java/bonda/bonda/domain/searchterm/application/SearchTermService.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/application/SearchTermService.java
@@ -1,0 +1,47 @@
+package bonda.bonda.domain.searchterm.application;
+
+import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.domain.member.domain.repository.MemberRepository;
+import bonda.bonda.domain.searchterm.dto.response.RecentSearchRes;
+import bonda.bonda.global.common.Message;
+import bonda.bonda.global.common.SuccessResponse;
+import bonda.bonda.infrastructure.redis.RedisListUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class SearchTermService {
+
+    private static final Integer MAX_RECENT_SEARCH_TERMS = 5;
+    private static final String RS_PREFIX = "RS_";  // RS = Recent Search : 최근 검색
+
+    private final MemberRepository memberRepository;
+
+    private final RedisListUtil redisUtil;
+
+    @Transactional
+    public SuccessResponse<Message> saveSearchTerm(Member member, String searchTerm) {
+        Message message;
+
+        if(!member.getAutoSave()){
+            message = Message.builder()
+                    .message("자동 저장이 꺼져 있어 검색어가 저장되지 않습니다.")
+                    .build();
+            return SuccessResponse.of(message);
+        }
+
+        redisUtil.addToRecentList(RS_PREFIX + member.getId(), searchTerm, MAX_RECENT_SEARCH_TERMS);
+
+        message = Message.builder()
+                .message("검색어가 저장이 되었습니다.")
+                .build();
+
+        return SuccessResponse.of(message);
+    }
+}

--- a/src/main/java/bonda/bonda/domain/searchterm/dto/response/RecentSearchRes.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/dto/response/RecentSearchRes.java
@@ -1,5 +1,6 @@
 package bonda.bonda.domain.searchterm.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,7 +10,11 @@ import java.util.List;
 @Builder
 public class RecentSearchRes {
 
+    @Schema(type = "List<String>",
+            example = "[\"최근 검색어 1\",\"최근 검색어 2\",\"최근 검색어 3\",\"최근 검색어 4\",\"최근 검색어 5\"]",
+            description = "회원의 최근 검색어 목록 리스트입니다. 최대 5개까지 저장됩니다.")
     private List<String> recentSearchTermList;
 
+    @Schema(type = "Boolean", example = "true", description = "회원의 검색어 자동 저장 허용 여부입니다. 자동 저장 허용 시 true를 출력합니다.")
     private Boolean autoSave;
 }

--- a/src/main/java/bonda/bonda/domain/searchterm/dto/response/RecentSearchRes.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/dto/response/RecentSearchRes.java
@@ -1,0 +1,15 @@
+package bonda.bonda.domain.searchterm.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class RecentSearchRes {
+
+    private List<String> recentSearchTermList;
+
+    private Boolean autoSave;
+}

--- a/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermApi.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermApi.java
@@ -1,0 +1,35 @@
+package bonda.bonda.domain.searchterm.presentation;
+
+import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.domain.searchterm.dto.response.RecentSearchRes;
+import bonda.bonda.global.annotation.LoginMember;
+import bonda.bonda.global.common.SuccessResponse;
+import bonda.bonda.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "SearchTerm API", description = "검색어 관련 API입니다.")
+public interface SearchTermApi {
+
+    @Operation(summary = "최근 검색어 목록 조회", description = "회원의 최근 검색어 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "최근 검색어 목록 조회 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = RecentSearchRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "최근 검색어 목록 조회 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            )
+    })
+    @GetMapping("/recent")
+    ResponseEntity<SuccessResponse<RecentSearchRes>> getRecentSearchTerms(
+            @Parameter(description = "최근 검색어 목록을 조회하고 싶은 회원의 AccessToken을 입력하세요.", required = true) @LoginMember Member member);
+}

--- a/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
@@ -14,10 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/search-term")
-public class SearchTermController {
+public class SearchTermController implements SearchTermApi {
 
     private final SearchTermService searchTermService;
 
+    @Override
     @GetMapping("/recent")
     public ResponseEntity<SuccessResponse<RecentSearchRes>> getRecentSearchTerms(@LoginMember Member member) {
         Long memberId = member.getId();

--- a/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
@@ -1,0 +1,26 @@
+package bonda.bonda.domain.searchterm.presentation;
+
+import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.domain.searchterm.application.SearchTermService;
+import bonda.bonda.domain.searchterm.dto.response.RecentSearchRes;
+import bonda.bonda.global.annotation.LoginMember;
+import bonda.bonda.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/search-term")
+public class SearchTermController {
+
+    private final SearchTermService searchTermService;
+
+    @GetMapping("/recent")
+    public ResponseEntity<SuccessResponse<RecentSearchRes>> getRecentSearchTerms(@LoginMember Member member) {
+        Long memberId = member.getId();
+        return ResponseEntity.ok(searchTermService.getRecentSearchTerms(memberId));
+    }
+}

--- a/src/main/java/bonda/bonda/infrastructure/redis/RedisListUtil.java
+++ b/src/main/java/bonda/bonda/infrastructure/redis/RedisListUtil.java
@@ -1,0 +1,36 @@
+package bonda.bonda.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class RedisListUtil {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void addToRecentList(String key, String value, int maxSize) {
+        ListOperations<String, String> listOperations = stringRedisTemplate.opsForList();
+        listOperations.remove(key, 0, value);           // 중복 제거
+        listOperations.leftPush(key, value);                  // 맨 앞에 삽입
+        listOperations.trim(key, 0, maxSize - 1);   // LRU 유지
+    }
+
+    public List<String> getList(String key) {
+        List<String> result = stringRedisTemplate.opsForList().range(key, 0, -1);
+        return result != null ? result : Collections.emptyList();
+    }
+
+    public void removeItem(String key, String value) {
+        stringRedisTemplate.opsForList().remove(key, 1,  value);
+    }
+
+    public void deleteList(String key) {
+        stringRedisTemplate.delete(key);
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [ ] 검색 시 검색어 저장 메서드 구현
- [ ] 최근 검색어 목록 조회

### 📷 스크린샷
- **검색 시 JWT 토큰 입력하도록 수정**
![스크린샷 2025-06-17 141635](https://github.com/user-attachments/assets/498c726c-0398-4712-acef-b791b55a47f8)
- **최근 검색 목록**
![스크린샷 2025-06-17 141641](https://github.com/user-attachments/assets/e61325ff-4808-49d6-9acb-dd38ac791558)
![스크린샷 2025-06-17 141723](https://github.com/user-attachments/assets/bedfc01e-7d67-4c2f-9fbe-6a0871049d38)


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #34 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

최근 검색어 목록 조회 api입니다.
1. 최근 검색어를 List형태로 관리하기 위한 RedisListUtil를 새로 만들었습니다. 하나의 키에 List를 value로 받아 최대치를 5개로 제한했습니다.
2. 최근 검색어 목록을 만들기 위해 이미 구현된 도서 검색에 saveSearchTerm 메서드를 추가했습니다. 최근 검색어 시 회원 정보가 필요하기 때문에 Controller에 jwt를 입력 받도록 추가했습니다.
3. 나머지는 읽어보시면 됩니다.