### PR TITLE
[FEAT]: 최근 검색어 개별 및 전체 삭제

### DIFF
--- a/src/main/java/bonda/bonda/domain/searchterm/application/SearchTermService.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/application/SearchTermService.java
@@ -62,4 +62,15 @@ public class SearchTermService {
 
         return SuccessResponse.of(message);
     }
+
+    @Transactional
+    public SuccessResponse<Message> deleteAllSearchTerm(Long memberId) {
+        redisUtil.deleteList(RS_PREFIX + memberId);
+
+        Message message = Message.builder()
+                .message("최근 검색어 전체 삭제 완료되었씁니다.")
+                .build();
+
+        return SuccessResponse.of(message);
+    }
 }

--- a/src/main/java/bonda/bonda/domain/searchterm/application/SearchTermService.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/application/SearchTermService.java
@@ -51,4 +51,15 @@ public class SearchTermService {
 
         return SuccessResponse.of(recentSearchRes);
     }
+
+    @Transactional
+    public SuccessResponse<Message> deleteSearchTerm(Long memberId, String keyword) {
+        redisUtil.removeItem(RS_PREFIX + memberId, keyword);
+
+        Message message = Message.builder()
+                .message("최근 검색어 " + keyword + " 삭제 완료되었습니다")
+                .build();
+
+        return SuccessResponse.of(message);
+    }
 }

--- a/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermApi.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermApi.java
@@ -3,6 +3,7 @@ package bonda.bonda.domain.searchterm.presentation;
 import bonda.bonda.domain.member.domain.Member;
 import bonda.bonda.domain.searchterm.dto.response.RecentSearchRes;
 import bonda.bonda.global.annotation.LoginMember;
+import bonda.bonda.global.common.Message;
 import bonda.bonda.global.common.SuccessResponse;
 import bonda.bonda.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,7 +14,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "SearchTerm API", description = "검색어 관련 API입니다.")
 public interface SearchTermApi {
@@ -32,4 +35,35 @@ public interface SearchTermApi {
     @GetMapping("/recent")
     ResponseEntity<SuccessResponse<RecentSearchRes>> getRecentSearchTerms(
             @Parameter(description = "최근 검색어 목록을 조회하고 싶은 회원의 AccessToken을 입력하세요.", required = true) @LoginMember Member member);
+
+    @Operation(summary = "최근 검색어 개별 삭제", description = "회원의 최근 검색어를 개별로 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "최근 검색어 개별 삭제 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "최근 검색어 개별 삭제 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            )
+    })
+    @DeleteMapping("/recent")
+    ResponseEntity<SuccessResponse<Message>> deleteSearchTerm(
+            @Parameter(description = "최근 검색어를 삭제하고 싶은 회원의 AccessToken을 입력하세요.", required = true) @LoginMember Member member,
+            @Parameter(description = "삭제할 최근 검색어를 parameter 값으로 입력하세요.") @RequestParam String keyword);
+
+    @Operation(summary = "최근 검색어 전체 삭제", description = "회원의 최근 검색어 전체를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "최근 검색어 전체 삭제 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "최근 검색어 전체 삭제 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            )
+    })
+    @DeleteMapping("/recent/all")
+    ResponseEntity<SuccessResponse<Message>> deleteAllSearchTerm(
+            @Parameter(description = "최근 검색어를 삭제하고 싶은 회원의 AccessToken을 입력하세요.", required = true) @LoginMember Member member);
 }

--- a/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
@@ -4,12 +4,11 @@ import bonda.bonda.domain.member.domain.Member;
 import bonda.bonda.domain.searchterm.application.SearchTermService;
 import bonda.bonda.domain.searchterm.dto.response.RecentSearchRes;
 import bonda.bonda.global.annotation.LoginMember;
+import bonda.bonda.global.common.Message;
 import bonda.bonda.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -23,5 +22,11 @@ public class SearchTermController implements SearchTermApi {
     public ResponseEntity<SuccessResponse<RecentSearchRes>> getRecentSearchTerms(@LoginMember Member member) {
         Long memberId = member.getId();
         return ResponseEntity.ok(searchTermService.getRecentSearchTerms(memberId));
+    }
+
+    @DeleteMapping("/recent")
+    public ResponseEntity<SuccessResponse<Message>> deleteSearchTerm(@LoginMember Member member, @RequestParam String keyword) {
+        Long memberId = member.getId();
+        return ResponseEntity.ok(searchTermService.deleteSearchTerm(memberId, keyword));
     }
 }

--- a/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
@@ -24,12 +24,14 @@ public class SearchTermController implements SearchTermApi {
         return ResponseEntity.ok(searchTermService.getRecentSearchTerms(memberId));
     }
 
+    @Override
     @DeleteMapping("/recent")
     public ResponseEntity<SuccessResponse<Message>> deleteSearchTerm(@LoginMember Member member, @RequestParam String keyword) {
         Long memberId = member.getId();
         return ResponseEntity.ok(searchTermService.deleteSearchTerm(memberId, keyword));
     }
 
+    @Override
     @DeleteMapping("/recent/all")
     public ResponseEntity<SuccessResponse<Message>> deleteAllSearchTerm(@LoginMember Member member) {
         Long memberId = member.getId();

--- a/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
@@ -29,4 +29,10 @@ public class SearchTermController implements SearchTermApi {
         Long memberId = member.getId();
         return ResponseEntity.ok(searchTermService.deleteSearchTerm(memberId, keyword));
     }
+
+    @DeleteMapping("/recent/all")
+    public ResponseEntity<SuccessResponse<Message>> deleteAllSearchTerm(@LoginMember Member member) {
+        Long memberId = member.getId();
+        return ResponseEntity.ok(searchTermService.deleteAllSearchTerm(memberId));
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 최근 검색어 개별 삭제
- [x] 최근 검색어 전체 삭제

### 📷 스크린샷
- **개별 삭제**
![스크린샷 2025-06-19 110247](https://github.com/user-attachments/assets/26fc0b18-3ae6-461a-a119-f09905e9c609)
- **전체 삭제**
![스크린샷 2025-06-19 111401](https://github.com/user-attachments/assets/5df47e4d-104b-41bb-905a-bbc8a9864c13)
![스크린샷 2025-06-19 111355](https://github.com/user-attachments/assets/c48d44fd-7cca-43b2-936e-aaa0786978ce)

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #41 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

최근 검색어 개별 및 전체 삭제 api입니다.
추가로 notion에 jwt 관련 파일 수정을 했습니다.(사유 : 유효 기간 수정 - 의도된 시간보다 1000배 곱해져있었음)
확인해주시고, 배포환경과 로컬에 모두 적용해주세요!
(적용하셨다면 redis 내 모든 데이터 한 번 삭제( **flushall** 입력)하시고 하시는걸 추천드립니다.)