### PR TITLE
[FEAT]: 최근 조회한 도서 목록 조회 

### DIFF
--- a/src/main/java/bonda/bonda/domain/book/application/BookReadService.java
+++ b/src/main/java/bonda/bonda/domain/book/application/BookReadService.java
@@ -1,9 +1,6 @@
 package bonda.bonda.domain.book.application;
 
-import bonda.bonda.domain.book.dto.response.BookDetailRes;
-import bonda.bonda.domain.book.dto.response.BookListByCategoryRes;
-import bonda.bonda.domain.book.dto.response.LovedBookListRes;
-import bonda.bonda.domain.book.dto.response.MySavedBookListRes;
+import bonda.bonda.domain.book.dto.response.*;
 import bonda.bonda.domain.member.domain.Member;
 import bonda.bonda.global.common.SuccessResponse;
 
@@ -15,5 +12,7 @@ public interface BookReadService {
     SuccessResponse<MySavedBookListRes> getMySavedBookList(int page, int size, String orderBy, Member member);
 
     SuccessResponse<BookDetailRes> getBookDetail(Long bookId, Member member);
+
+    SuccessResponse<RecentViewBookListRes> getRecentViewBookList(int page, int size,Member member);
 }
 

--- a/src/main/java/bonda/bonda/domain/book/application/BookReadServiceImpl.java
+++ b/src/main/java/bonda/bonda/domain/book/application/BookReadServiceImpl.java
@@ -101,6 +101,18 @@ public class BookReadServiceImpl implements BookReadService {
         return SuccessResponse.of(viewAndBadgeCheck(member, book, bookDetailRes));// 조회 기록 및 뱃지 처리해서 응답 반환
     }
 
+    @Override
+    public SuccessResponse<RecentViewBookListRes> getRecentViewBookList(int page, int size,Member member) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Book> recentViewBookList = bookRepository.findRecentViewBookList(member, pageable);
+        List<BookListRes> bookListRes = convertToBookListRes(recentViewBookList.getContent());
+        return SuccessResponse.of(RecentViewBookListRes.builder()
+                .page(page)
+                .hasNextPage(recentViewBookList.hasNext())
+                .bookList(bookListRes)
+                .build());
+    }
+
     /**책 기본 정보와 북마크 여부 조회 및 res 일부 체우기**/
     private BookDetailRes getBookDetailResWithIsBookMarked(Long bookId, Member member) {
         BookDetailRes bookDetailRes = bookRepository.findBookDetailResWithIsBookMarked(bookId, member); //도서 기본 정보 체우기

--- a/src/main/java/bonda/bonda/domain/book/application/BookReadServiceImpl.java
+++ b/src/main/java/bonda/bonda/domain/book/application/BookReadServiceImpl.java
@@ -10,7 +10,9 @@ import bonda.bonda.domain.book.domain.repository.BookRepository;
 import bonda.bonda.domain.book.dto.response.*;
 import bonda.bonda.domain.bookarticle.BookArticle;
 import bonda.bonda.domain.bookarticle.repository.BookArticleRepository;
+import bonda.bonda.domain.member.application.MemberService;
 import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.domain.member.domain.repository.MemberRepository;
 import bonda.bonda.domain.recentviewbook.RecentViewBook;
 import bonda.bonda.domain.recentviewbook.repository.RecentViewBookRepository;
 import bonda.bonda.global.common.SuccessResponse;
@@ -39,6 +41,8 @@ public class BookReadServiceImpl implements BookReadService {
     private final BookArticleRepository bookArticleRepository;
     private final RecentViewBookRepository recentViewBookRepository;
     private final BadgeService badgeService;
+    private final MemberRepository memberRepository;
+
     @Override
     public SuccessResponse<BookListByCategoryRes> bookListByCategory(Integer page, Integer size, String orderBy, String category) {
         if (BookCategory.isValid(category) == false) {
@@ -95,10 +99,12 @@ public class BookReadServiceImpl implements BookReadService {
     @Override
     @Transactional
     public SuccessResponse<BookDetailRes> getBookDetail(Long bookId, Member member) {
+        // 멤버 조회 -> 영속 상태로 조회
+        Member persistMember = memberRepository.findByKakaoId(member.getKakaoId()).orElseThrow(() -> new BusinessException(INVALID_MEMBER));
         //책 조회 -> 없으면 오류
         Book book = bookRepository.findById(bookId).orElseThrow(() -> new BusinessException(INVALID_BOOK_Id));
-        BookDetailRes bookDetailRes = getBookDetailResWithIsBookMarked(bookId, member); //응답에 기본 정보 체우기
-        return SuccessResponse.of(viewAndBadgeCheck(member, book, bookDetailRes));// 조회 기록 및 뱃지 처리해서 응답 반환
+        BookDetailRes bookDetailRes = getBookDetailResWithIsBookMarked(bookId, persistMember); //응답에 기본 정보 체우기
+        return SuccessResponse.of(viewAndBadgeCheck(persistMember, book, bookDetailRes));// 조회 기록 및 뱃지 처리해서 응답 반환
     }
 
     @Override

--- a/src/main/java/bonda/bonda/domain/book/domain/repository/BookRepositoryCustom.java
+++ b/src/main/java/bonda/bonda/domain/book/domain/repository/BookRepositoryCustom.java
@@ -21,4 +21,6 @@ public interface BookRepositoryCustom {
     Page<Book> findMySavedBookList(Pageable pageable, String orderBy, Member member);
 
     BookDetailRes findBookDetailResWithIsBookMarked(Long bookId, Member member);
+
+    Page<Book> findRecentViewBookList(Member member, Pageable pageable);
 }

--- a/src/main/java/bonda/bonda/domain/book/dto/response/BookListRes.java
+++ b/src/main/java/bonda/bonda/domain/book/dto/response/BookListRes.java
@@ -1,15 +1,22 @@
 package bonda.bonda.domain.book.dto.response;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
+@Schema(description = "도서 객체 응답 DTO")
 public class BookListRes {
+    @Schema(description = "도서 아이디", example = "1")
     Long id;
+    @Schema(description = "도서 제목", example = "title")
     String title;
+    @Schema(description = "도서 작가", example = "author")
     String author;
+    @Schema(description = "도서 이미지 url")
     String imageUrl;
+    @Schema(description = "도서 주제", example = "true")
     String subject;
 }

--- a/src/main/java/bonda/bonda/domain/book/dto/response/RecentViewBookListRes.java
+++ b/src/main/java/bonda/bonda/domain/book/dto/response/RecentViewBookListRes.java
@@ -1,0 +1,14 @@
+package bonda.bonda.domain.book.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class RecentViewBookListRes {
+    Integer page;
+    Boolean hasNextPage;
+    List<BookListRes> bookList;
+}

--- a/src/main/java/bonda/bonda/domain/book/dto/response/RecentViewBookListRes.java
+++ b/src/main/java/bonda/bonda/domain/book/dto/response/RecentViewBookListRes.java
@@ -1,5 +1,6 @@
 package bonda.bonda.domain.book.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,8 +8,12 @@ import java.util.List;
 
 @Data
 @Builder
+@Schema(description = "최근 조회한 도서 목록 응답 DTO")
 public class RecentViewBookListRes {
+    @Schema(description = "요청 페이지", example = "0")
     Integer page;
+    @Schema(description = "다음 페이지 존재 여부", example = "false")
     Boolean hasNextPage;
+    @Schema(description = "도서 리스트 목록 dto", example = "0")
     List<BookListRes> bookList;
 }

--- a/src/main/java/bonda/bonda/domain/book/presentation/BookApi.java
+++ b/src/main/java/bonda/bonda/domain/book/presentation/BookApi.java
@@ -205,5 +205,26 @@ public interface BookApi {
             @PathVariable(value = "bookId") Long bookId,
             @Parameter(hidden = true) // Swagger에 표시하지 않음 (내부에서 주입되는 로그인 사용자 정보)
             @LoginMember Member member);
+
+
+    @Operation(summary = "최근 조회한 도서 목록 조회", description = "최근 조회한 도서 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "도서 조회 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = RecentViewBookListRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            )
+    })
+    @GetMapping("/my-recent-views")
+    ResponseEntity<SuccessResponse<RecentViewBookListRes>> getRecentViewBookList(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지당 항목 수", example = "24")
+            @RequestParam(defaultValue = "24") int size,
+            @Parameter(hidden = true) // Swagger에 표시하지 않음 (내부에서 주입되는 로그인 사용자 정보)
+            @LoginMember Member member);
 }
 

--- a/src/main/java/bonda/bonda/domain/book/presentation/BookApi.java
+++ b/src/main/java/bonda/bonda/domain/book/presentation/BookApi.java
@@ -205,5 +205,5 @@ public interface BookApi {
             @PathVariable(value = "bookId") Long bookId,
             @Parameter(hidden = true) // Swagger에 표시하지 않음 (내부에서 주입되는 로그인 사용자 정보)
             @LoginMember Member member);
-    }
+}
 

--- a/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
+++ b/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
@@ -84,6 +84,7 @@ public class BookController implements BookApi {
         return ResponseEntity.ok(bookReadService.getBookDetail(bookId, member));
     }
 
+    @Override
     @GetMapping("/my-recent-views")
     public ResponseEntity<SuccessResponse<RecentViewBookListRes>> getRecentViewBookList(
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
+++ b/src/main/java/bonda/bonda/domain/book/presentation/BookController.java
@@ -83,4 +83,12 @@ public class BookController implements BookApi {
     public ResponseEntity<SuccessResponse<BookDetailRes>> getBookDetail(@PathVariable(value = "bookId") Long bookId, @LoginMember Member member) {
         return ResponseEntity.ok(bookReadService.getBookDetail(bookId, member));
     }
+
+    @GetMapping("/my-recent-views")
+    public ResponseEntity<SuccessResponse<RecentViewBookListRes>> getRecentViewBookList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "24") int size,
+            @LoginMember Member member) {
+        return ResponseEntity.ok(bookReadService.getRecentViewBookList(page, size, member));
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요
![image](https://github.com/user-attachments/assets/f102d737-c66d-4224-b199-dbc4ecc9a78a)


- [x] 도서 조회 기능 구현
- [x] swagger 문서 작성 

### 📷 스크린샷
현재 10개 
![image](https://github.com/user-attachments/assets/6b401526-68b8-4e07-bd53-fc7dc12c69a7)
![image](https://github.com/user-attachments/assets/cc60f0b5-9af1-4f3d-b2d6-63d3e172f569)

이미 존재하는 1번 도서 다시 조회 (최근 상단으로 올라오는 것을 기대)
![image](https://github.com/user-attachments/assets/7900270b-6fc2-43b5-abbe-2b5d6513c09a)
![image](https://github.com/user-attachments/assets/27846973-36ab-4ec9-a6b1-f6602d6c7c69)

새로운 도서 조회 (11번 아이디)
![image](https://github.com/user-attachments/assets/dd31b003-9c43-497a-a47a-e267ddb97fa9)
![image](https://github.com/user-attachments/assets/3a8f0230-cdc4-4c3d-9351-ff859123c696)


--쿼리 조회--
select
            b1_0.id,
            b1_0.book_category,
            b1_0.content,
            b1_0.created_at,
            b1_0.image,
            b1_0.introduction,
            b1_0.page,
            b1_0.publish_date,
            b1_0.publisher,
            b1_0.size,
            b1_0.subject,
            b1_0.title,
            b1_0.writer 
        from
            book b1_0 
        join
            recent_view_book rvb1_0  // 최근 조회한 도서와 inner 조인
                on rvb1_0.member_id=?  // 멤버
                and rvb1_0.book_id=b1_0.id  // 도서 
        order by
            rvb1_0.view_date desc  // view-date 기준 내림차순
        limit
            ?, ? 
-- 다음 페이지 존재 여부 위한 카운트 쿼리--
select
            count(b1_0.id) 
        from
            book b1_0 
        join
            recent_view_book rvb1_0 
                on rvb1_0.book_id=b1_0.id 
                and rvb1_0.member_id=?

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호
#40 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요
최근 조회한 도서라서, 리포에서 재사용하기 어려울 거라고 판단해서,
따로 메소드로 하나 따로 만들었습니다.

추가로, 기존 상세 조회 시, 뱃지 생성 되었을 때, 뱃지 카운트 상승이  안 되는 버그를
발견해서, 멤버를 영속화 해서 넘겨 주는 방식으로 해결하였습니다.