### PR TITLE
[FEAT]: 검색어 자동 저장 여부 변경

### DIFF
--- a/src/main/java/bonda/bonda/domain/member/domain/Member.java
+++ b/src/main/java/bonda/bonda/domain/member/domain/Member.java
@@ -62,4 +62,8 @@ public class Member extends BaseEntity {
         this.badgeCount++;
     }
 
+    public void updateAutoSave(Boolean autoSave) {
+        this.autoSave = autoSave;
+    }
+
 }

--- a/src/main/java/bonda/bonda/domain/searchterm/application/SearchTermService.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/application/SearchTermService.java
@@ -2,6 +2,7 @@ package bonda.bonda.domain.searchterm.application;
 
 import bonda.bonda.domain.member.domain.Member;
 import bonda.bonda.domain.member.domain.repository.MemberRepository;
+import bonda.bonda.domain.searchterm.dto.response.ModifyAutoSave;
 import bonda.bonda.domain.searchterm.dto.response.RecentSearchRes;
 import bonda.bonda.domain.searchterm.dto.response.RecommendKeywordsRes;
 import bonda.bonda.global.common.Message;
@@ -100,5 +101,24 @@ public class SearchTermService {
                 .build();
 
         return SuccessResponse.of(recommendKeywordsRes);
+    }
+
+    @Transactional
+    public SuccessResponse<ModifyAutoSave> modifyAutoSave(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadCredentialsException("해당 아이디를 가진 멤버가 없습니다."));
+
+        Boolean autoSave = member.getAutoSave();
+        member.updateAutoSave(!autoSave);   // true -> false / false -> true
+
+        if(autoSave) {
+            redisUtil.deleteList(RS_PREFIX + memberId);
+        }
+
+        ModifyAutoSave modifyAutoSave = ModifyAutoSave.builder()
+                .autoSave(!autoSave)
+                .build();
+
+        return SuccessResponse.of(modifyAutoSave);
     }
 }

--- a/src/main/java/bonda/bonda/domain/searchterm/dto/response/ModifyAutoSave.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/dto/response/ModifyAutoSave.java
@@ -1,0 +1,11 @@
+package bonda.bonda.domain.searchterm.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ModifyAutoSave {
+
+    private Boolean autoSave;
+}

--- a/src/main/java/bonda/bonda/domain/searchterm/dto/response/ModifyAutoSave.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/dto/response/ModifyAutoSave.java
@@ -1,5 +1,6 @@
 package bonda.bonda.domain.searchterm.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,5 +8,6 @@ import lombok.Data;
 @Builder
 public class ModifyAutoSave {
 
+    @Schema(type = "Boolean", example = "true", description = "회원의 검색어 자동 저장 허용 여부입니다. 자동 저장 허용 시 true를 출력합니다.")
     private Boolean autoSave;
 }

--- a/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermApi.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermApi.java
@@ -1,6 +1,7 @@
 package bonda.bonda.domain.searchterm.presentation;
 
 import bonda.bonda.domain.member.domain.Member;
+import bonda.bonda.domain.searchterm.dto.response.ModifyAutoSave;
 import bonda.bonda.domain.searchterm.dto.response.RecentSearchRes;
 import bonda.bonda.domain.searchterm.dto.response.RecommendKeywordsRes;
 import bonda.bonda.global.annotation.LoginMember;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "SearchTerm API", description = "검색어 관련 API입니다.")
@@ -81,4 +83,19 @@ public interface SearchTermApi {
     })
     @GetMapping("/recommend")
     ResponseEntity<SuccessResponse<RecommendKeywordsRes>> getRecommendKeywords();
+
+    @Operation(summary = "검색어 자동 저장 여부 변경", description = "회원의 최근 검색어 자동 저장 여부를 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "검색어 자동 저장 여부 변경 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "검색어 자동 저장 여부 변경 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            )
+    })
+    @PatchMapping("/auto-save")
+    ResponseEntity<SuccessResponse<ModifyAutoSave>> modifyAutoSave(
+            @Parameter(description = "검색어 자동 저장 여부를 변경하고 싶은 회원의 AccessToken을 입력하세요.", required = true) @LoginMember Member member);
 }

--- a/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
+++ b/src/main/java/bonda/bonda/domain/searchterm/presentation/SearchTermController.java
@@ -2,6 +2,7 @@ package bonda.bonda.domain.searchterm.presentation;
 
 import bonda.bonda.domain.member.domain.Member;
 import bonda.bonda.domain.searchterm.application.SearchTermService;
+import bonda.bonda.domain.searchterm.dto.response.ModifyAutoSave;
 import bonda.bonda.domain.searchterm.dto.response.RecentSearchRes;
 import bonda.bonda.domain.searchterm.dto.response.RecommendKeywordsRes;
 import bonda.bonda.global.annotation.LoginMember;
@@ -43,5 +44,11 @@ public class SearchTermController implements SearchTermApi {
     @GetMapping("/recommend")
     public ResponseEntity<SuccessResponse<RecommendKeywordsRes>> getRecommendKeywords() {
         return ResponseEntity.ok(searchTermService.getRecommendKeyword());
+    }
+
+    @PatchMapping("/auto-save")
+    public ResponseEntity<SuccessResponse<ModifyAutoSave>> modifyAutoSave(@LoginMember Member member) {
+        Long memberId = member.getId();
+        return ResponseEntity.ok(searchTermService.modifyAutoSave(memberId));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 검색어 자동 저장 여부 변경 api 개발


### 📷 스크린샷
- **DB 체크** (true인 상태)
![스크린샷 2025-06-20 154322](https://github.com/user-attachments/assets/47ca876c-f425-4435-843c-37fe7603a4c8)
- **API 응답값** true -> false
![스크린샷 2025-06-20 154714](https://github.com/user-attachments/assets/76599e6e-6c59-40f8-868f-a0f648ab2698)
- **DB 변환 여부 체크**
![스크린샷 2025-06-20 154721](https://github.com/user-attachments/assets/1ed3c628-a3aa-48eb-a030-5b3863eda25a)
- **Redis 확인** -> false로 변환 시 검색어 key 삭제
![스크린샷 2025-06-20 154933](https://github.com/user-attachments/assets/eb970602-5f34-4be4-a4b3-741c578de70a)
- 반대의 경우도 확인
![스크린샷 2025-06-20 155721](https://github.com/user-attachments/assets/a6e57d04-bb46-4f01-8326-38ec8fcf0b47)


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #49 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

자동 저장 여부를 변경합니다.