### PR TITLE
[FEAT]: 뱃지 상세 내용 조회

### DIFF
--- a/src/main/java/bonda/bonda/domain/badge/dto/response/BadgeDetailsRes.java
+++ b/src/main/java/bonda/bonda/domain/badge/dto/response/BadgeDetailsRes.java
@@ -1,18 +1,26 @@
 package bonda.bonda.domain.badge.dto.response;
 
 import bonda.bonda.domain.badge.domain.ProgressType;
+import lombok.Builder;
+import lombok.Data;
 
+import java.time.LocalDate;
+
+@Data
+@Builder
 public class BadgeDetailsRes {
 
     private String name;
 
     private String description;
 
-    private String image;
-
     private ProgressType progressType;
+
+    private Integer currentProgress;
 
     private Integer goal;
 
     private Boolean isUnlocked;
+
+    private LocalDate acquiredDate;
 }

--- a/src/main/java/bonda/bonda/domain/badge/dto/response/BadgeDetailsRes.java
+++ b/src/main/java/bonda/bonda/domain/badge/dto/response/BadgeDetailsRes.java
@@ -1,6 +1,7 @@
 package bonda.bonda.domain.badge.dto.response;
 
 import bonda.bonda.domain.badge.domain.ProgressType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,17 +11,24 @@ import java.time.LocalDate;
 @Builder
 public class BadgeDetailsRes {
 
+    @Schema(type = "String", example = "느긋한 발걸음", description = "뱃지의 이름을 출력합니다.")
     private String name;
 
+    @Schema(type = "String", example = "첫 도서 상세페이지를 조회하면 획득할 수 있어요.", description = "뱃지의 설명을 출력합니다. 획득 시 설명이 변경됩니다.")
     private String description;
 
+    @Schema(type = "Enum", example = "BOOK_VIEW", description = "뱃지의 타입을 BOOK_VIEW, BOOK_SAVE, ARTICLE_VIEW, ARTICLE_SAVE로 구분합니다.")
     private ProgressType progressType;
 
+    @Schema(type = "Integer", example = "1", description = "현재 진척도를 출력합니다.")
     private Integer currentProgress;
 
+    @Schema(type = "Integer", example = "1", description = "뱃지를 얻기 위한 목표치를 출력합니다.")
     private Integer goal;
 
+    @Schema(type = "Boolean", example = "true", description = "뱃지 획득 여부를 출력합니다. true면 회원이 뱃지를 획득했음을 의미합니다.")
     private Boolean isUnlocked;
 
+    @Schema(type = "LocalDate", example = "2025-01-01", description = "뱃지 획득 날짜를 출력합니다.")
     private LocalDate acquiredDate;
 }

--- a/src/main/java/bonda/bonda/domain/badge/dto/response/BadgeRes.java
+++ b/src/main/java/bonda/bonda/domain/badge/dto/response/BadgeRes.java
@@ -14,9 +14,6 @@ public class BadgeRes {
     @Schema(type = "String", example = "느긋한 발걸음", description = "뱃지의 이름을 출력합니다.")
     private String name;
 
-    @Schema(type = "String", example = "BOOK_VIEW_1.png", description = "뱃지의 이미지 url을 출력합니다.")
-    private String image;
-
     @Schema(type = "Boolean", example = "true", description = "뱃지 획득 여부를 출력합니다. true면 회원이 뱃지를 획득했음을 의미합니다.")
     private Boolean isUnlocked;
 }

--- a/src/main/java/bonda/bonda/domain/badge/presentation/BadgeApi.java
+++ b/src/main/java/bonda/bonda/domain/badge/presentation/BadgeApi.java
@@ -1,6 +1,7 @@
 package bonda.bonda.domain.badge.presentation;
 
 import bonda.bonda.domain.auth.dto.response.LoginRes;
+import bonda.bonda.domain.badge.dto.response.BadgeDetailsRes;
 import bonda.bonda.domain.badge.dto.response.MyBadgeListRes;
 import bonda.bonda.domain.member.domain.Member;
 import bonda.bonda.global.annotation.LoginMember;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Badge API", description = "뱃지 관련 API입니다.")
 public interface BadgeApi {
@@ -33,4 +35,20 @@ public interface BadgeApi {
     @GetMapping("/me")
     ResponseEntity<SuccessResponse<MyBadgeListRes>> getMyBadgeList(
             @Parameter(description = "소유한 뱃지 목록을 확인하고 싶은 멤버의 accessToken을 입력하시오.", required = true) @LoginMember Member member);
+
+    @Operation(summary = "회원 뱃지 상세 조회", description = "회원이 소유한 뱃지의 상세 내용을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "회원 뱃지 상세 조회 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = BadgeDetailsRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "회원 뱃지 상세 조회 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorCode.class))}
+            )
+    })
+    @GetMapping("/{badgeId}")
+    ResponseEntity<SuccessResponse<BadgeDetailsRes>> getBadgeDetails(
+            @Parameter(description = "뱃지 상세 목록을 확인하고 싶은 멤버의 accessToken을 입력하시오.", required = true) @LoginMember Member member,
+            @Parameter(description = "상세 조회하고 싶은 뱃지 아이디 번호를 입력하시오.", required = true) @PathVariable Long badgeId);
 }

--- a/src/main/java/bonda/bonda/domain/badge/presentation/BadgeController.java
+++ b/src/main/java/bonda/bonda/domain/badge/presentation/BadgeController.java
@@ -1,6 +1,7 @@
 package bonda.bonda.domain.badge.presentation;
 
 import bonda.bonda.domain.badge.application.BadgeService;
+import bonda.bonda.domain.badge.dto.response.BadgeDetailsRes;
 import bonda.bonda.domain.badge.dto.response.MyBadgeListRes;
 import bonda.bonda.domain.member.domain.Member;
 import bonda.bonda.global.annotation.LoginMember;
@@ -8,6 +9,7 @@ import bonda.bonda.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,5 +25,11 @@ public class BadgeController implements BadgeApi {
     public ResponseEntity<SuccessResponse<MyBadgeListRes>> getMyBadgeList(@LoginMember Member member) {
         Long memberId = member.getId();
         return ResponseEntity.ok(badgeService.getMyBadgeList(memberId));
+    }
+
+    @GetMapping("/{badgeId}")
+    public ResponseEntity<SuccessResponse<BadgeDetailsRes>> getBadgeDetails(@LoginMember Member member, @PathVariable Long badgeId) {
+        Long memberId = member.getId();
+        return ResponseEntity.ok(badgeService.getBadgeDetails(memberId, badgeId));
     }
 }

--- a/src/main/java/bonda/bonda/domain/badge/presentation/BadgeController.java
+++ b/src/main/java/bonda/bonda/domain/badge/presentation/BadgeController.java
@@ -27,6 +27,7 @@ public class BadgeController implements BadgeApi {
         return ResponseEntity.ok(badgeService.getMyBadgeList(memberId));
     }
 
+    @Override
     @GetMapping("/{badgeId}")
     public ResponseEntity<SuccessResponse<BadgeDetailsRes>> getBadgeDetails(@LoginMember Member member, @PathVariable Long badgeId) {
         Long memberId = member.getId();

--- a/src/main/java/bonda/bonda/domain/memberbadge/repository/MemberBadgeRepository.java
+++ b/src/main/java/bonda/bonda/domain/memberbadge/repository/MemberBadgeRepository.java
@@ -6,6 +6,7 @@ import bonda.bonda.domain.memberbadge.MemberBadge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long> {
@@ -13,4 +14,6 @@ public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long> 
     boolean existsByMemberAndBadge(Member member, Badge badge);
 
     List<MemberBadge> findByMember(Member member);
+
+    Optional<MemberBadge> findByMemberAndBadge(Member member, Badge badge);
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 뱃지 목록 조회 리팩토링
- [x] 뱃지 상세 내용 조회

### 📷 스크린샷
- 뱃지 얻기 전 상세 내용 조회
![스크린샷 2025-06-25 151056](https://github.com/user-attachments/assets/4f706c30-9e8c-4ed7-ac0e-0929ad767bf6)
- 뱃지 얻은 후 상세 내용 조회
![스크린샷 2025-06-25 151348](https://github.com/user-attachments/assets/27c562c4-016b-4854-bcc6-d35c98652bf8)
- 예외처리(뱃지 번호가 잘못된 경우)
![스크린샷 2025-06-25 151106](https://github.com/user-attachments/assets/91de771f-a498-4c2f-b2e4-15085ec085e0)

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #61 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

뱃지 관련 Response 값에 이미지를 전부 제거했습니다.
뱃지 description을 얻기 전 후에 따라서 달라지도록 설정했습니다.
첫 도서 상세페이지는 사진처럼 "도서"만 나오도록 설정했습니다. 추후 리팩토링 가능하면 리팩토링 할 예정입니다.