### PR TITLE
[FIX]: 도서 상세조회 시 고화질 이미지 반환

### DIFF
--- a/src/main/java/bonda/bonda/domain/book/domain/Book.java
+++ b/src/main/java/bonda/bonda/domain/book/domain/Book.java
@@ -21,6 +21,8 @@ public class Book extends BaseEntity {
 
     private String image;
 
+    private String highImage;
+
     private String title;
 
     private String writer;

--- a/src/main/java/bonda/bonda/domain/book/domain/repository/BookRepositoryImpl.java
+++ b/src/main/java/bonda/bonda/domain/book/domain/repository/BookRepositoryImpl.java
@@ -92,7 +92,7 @@ public class BookRepositoryImpl implements BookRepositoryCustom {
                 .select(
                         book.bookCategory,
                         book.title,
-                        book.image,
+                        book.highImage,
                         book.writer,
                         book.publisher,
                         book.size,
@@ -110,7 +110,7 @@ public class BookRepositoryImpl implements BookRepositoryCustom {
                 .bookId(bookId)
                 .category(tuple.get(book.bookCategory))
                 .title(tuple.get(book.title))
-                .imageUrl(tuple.get(book.image))
+                .imageUrl(tuple.get(book.highImage))
                 .author(tuple.get(book.writer))
                 .publisher(tuple.get(book.publisher))
                 .plateType(tuple.get(book.size))


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [ ] rds 상에서 high_image 컬럼 추가 및 cover500으로 고화질로 데이터 체우기

<img width="1464" height="421" alt="image" src="https://github.com/user-attachments/assets/59ef1513-95ee-40af-a0ce-9acd998bbfd4" />

- [ ] 엔티티에 highImage 추가 및 도서 상세 조회 시, highImage 반환하도록 수정


### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [ ] 테스트는 잘 통과했나요?
- [ ] 충돌을 해결했나요?
- [ ] 이슈는 등록했나요?
- [ ] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요
기존 정보가 있어서, rds 상에서 컬럼 추가하고, 데이터 집어 넣었습니다!